### PR TITLE
fix(vscode): exclude syntax highlight from ignore

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -4,3 +4,4 @@
 !icons/ungram.png
 !LICENSE
 !dist/
+!syntaxes/*.tmLanguage.json


### PR DESCRIPTION
Fix #65 